### PR TITLE
Исправлена ошибка с прокруткой галении превью

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -230,6 +230,10 @@ export default class ImageGallery extends React.Component {
     if (this._thumbnailsWrapper && thumbnailNavSwitched) {
       this._updateThumbnailWrapperSize();
     }
+
+    if (prevState.isFullscreen !== this.state.isFullscreen) {
+      this._updateThumbnailTranslate(prevState.currentIndex, prevState.currentThumbnailIndex);
+    }
   }
 
   componentDidMount() {
@@ -325,7 +329,6 @@ export default class ImageGallery extends React.Component {
     }
 
     this.setState({isFullscreen: true});
-
   }
 
   exitFullScreen() {
@@ -348,7 +351,6 @@ export default class ImageGallery extends React.Component {
       }
 
       this.setState({isFullscreen: false});
-
     }
   }
 
@@ -468,15 +470,11 @@ export default class ImageGallery extends React.Component {
   }, 300);
 
   _handleResize = () => {
-    const { currentIndex } = this.state;
     if (this._imageGallery) {
       this.setState({
         galleryWidth: this._imageGallery.offsetWidth
       });
     }
-
-    // adjust thumbnail container when thumbnail width or height is adjusted
-    this._setThumbsTranslate(0);
 
     if (this._imageGallerySlideWrapper) {
       this.setState({
@@ -487,9 +485,6 @@ export default class ImageGallery extends React.Component {
     if (this._thumbnailsWrapper) {
       this._updateThumbnailWrapperSize();
     }
-
-    // Adjust thumbnail container when thumbnail width or height is adjusted
-    this._setThumbsTranslate(-this._getThumbsTranslate(currentIndex));
   };
 
   _updateThumbnailWrapperSize = () => {
@@ -650,10 +645,13 @@ export default class ImageGallery extends React.Component {
     } else {
       const columns = this._getThumbsColumns();
       const scrollLimit = this._getThumbsTranslateLimit();
+
       const indexDifference = (previousThumbnailIndex < currentThumbnailIndex)
         ? Math.floor(currentThumbnailIndex / columns) - Math.floor(previousThumbnailIndex / columns)
         : Math.ceil(previousThumbnailIndex / columns) - Math.ceil(currentThumbnailIndex / columns);
+
       const scroll = this._getThumbsTranslate(indexDifference);
+
       if (scroll > 0) {
         if (previousThumbnailIndex < currentThumbnailIndex) {
           this._setThumbsTranslate(Math.abs(thumbsTranslate - scroll) >= scrollLimit
@@ -1086,7 +1084,7 @@ export default class ImageGallery extends React.Component {
       thumbsTranslate,
     } = this.state;
     const scrollLimit = this._getThumbsTranslateLimit();
-
+    
     if (this._isThumbnailVertical()) {
       this._setThumbsTranslate(thumbsTranslate >= 0 ? -scrollLimit
         : Math.min(thumbsTranslate + thumbnailsWrapperHeight, 0));

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -230,10 +230,6 @@ export default class ImageGallery extends React.Component {
     if (this._thumbnailsWrapper && thumbnailNavSwitched) {
       this._updateThumbnailWrapperSize();
     }
-
-    if (prevState.isFullscreen !== this.state.isFullscreen) {
-      this._updateThumbnailTranslate(prevState.currentIndex, prevState.currentThumbnailIndex);
-    }
   }
 
   componentDidMount() {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -493,14 +493,13 @@ export default class ImageGallery extends React.Component {
   };
 
   _updateThumbnailWrapperSize = () => {
-    if (this._isThumbnailHorizontal()) {
-      this.setState({thumbnailsWrapperHeight: this._thumbnailsWrapper.offsetHeight});
-    } else {
-      this.setState({thumbnailsWrapperWidth: this._thumbnailsWrapper.offsetWidth});
-    }
+    this.setState({
+      thumbnailsWrapperHeight: this._thumbnailsWrapper.offsetHeight,
+      thumbnailsWrapperWidth: this._thumbnailsWrapper.offsetWidth,
+    });
   }
 
-  _isThumbnailHorizontal() {
+  _isThumbnailVertical() {
     const { thumbnailPosition } = this.props;
     return thumbnailPosition === 'left' || thumbnailPosition === 'right';
   }
@@ -672,7 +671,7 @@ export default class ImageGallery extends React.Component {
     if (this._thumbnails && this._thumbnails.children && this._thumbnails.children.length) {
       const { width, height } = this._thumbnails.children[0].getBoundingClientRect();
 
-      if (this._isThumbnailHorizontal()) {
+      if (this._isThumbnailVertical()) {
         return Math.floor(thumbnailsWrapperWidth / width) || 1;
       } else {
         return Math.floor(thumbnailsWrapperHeight / height) || 1;
@@ -685,7 +684,7 @@ export default class ImageGallery extends React.Component {
   _getThumbsTranslateLimit() {
     const {thumbnailsWrapperWidth,thumbnailsWrapperHeight} = this.state;
 
-    if (this._isThumbnailHorizontal()) {
+    if (this._isThumbnailVertical()) {
       return this._thumbnails.scrollHeight - thumbnailsWrapperHeight;
     }
 
@@ -706,7 +705,7 @@ export default class ImageGallery extends React.Component {
 
     if (this._thumbnails) {
       // total scroll required to see the last thumbnail
-      if (this._isThumbnailHorizontal()) {
+      if (this._isThumbnailVertical()) {
         if (this._thumbnails.scrollHeight <= thumbnailsWrapperHeight) {
           return 0;
         }
@@ -840,7 +839,7 @@ export default class ImageGallery extends React.Component {
   }
 
   _getThumbnailBarHeight() {
-    if (this._isThumbnailHorizontal()) {
+    if (this._isThumbnailVertical()) {
       return {
         height: this.props.showThumbnailsNav && this._showThumbnailsNav()
           ? this.state.gallerySlideWrapperHeight - 50
@@ -948,7 +947,7 @@ export default class ImageGallery extends React.Component {
     const { thumbsTranslate } = this.state;
     const verticalTranslateValue = isRTL ? thumbsTranslate * -1 : thumbsTranslate;
 
-    if (this._isThumbnailHorizontal()) {
+    if (this._isThumbnailVertical()) {
       translate = `translate(0, ${thumbsTranslate}px)`;
       if (useTranslate3D) {
         translate = `translate3d(0, ${thumbsTranslate}px, 0)`;
@@ -1057,7 +1056,7 @@ export default class ImageGallery extends React.Component {
 
     if (this._thumbnails) {
 
-      if (this._isThumbnailHorizontal()) {
+      if (this._isThumbnailVertical()) {
         return !!(thumbnailsWrapperHeight && this._thumbnails.scrollHeight > thumbnailsWrapperHeight);
       }
 
@@ -1088,7 +1087,7 @@ export default class ImageGallery extends React.Component {
     } = this.state;
     const scrollLimit = this._getThumbsTranslateLimit();
 
-    if (this._isThumbnailHorizontal()) {
+    if (this._isThumbnailVertical()) {
       this._setThumbsTranslate(thumbsTranslate >= 0 ? -scrollLimit
         : Math.min(thumbsTranslate + thumbnailsWrapperHeight, 0));
     } else {
@@ -1105,7 +1104,7 @@ export default class ImageGallery extends React.Component {
       } = this.state;
     const scrollLimit = this._getThumbsTranslateLimit();
 
-    if (this._isThumbnailHorizontal()) {
+    if (this._isThumbnailVertical()) {
       this._setThumbsTranslate(thumbsTranslate <= -scrollLimit ? 0
         : Math.max(thumbsTranslate - thumbnailsWrapperHeight, -scrollLimit));
     } else {
@@ -1353,17 +1352,17 @@ export default class ImageGallery extends React.Component {
           {
             this.props.showThumbnails &&
               <div
-                className={`image-gallery-thumbnails-wrapper ${thumbnailNavClass} ${thumbnailPosition} ${!this._isThumbnailHorizontal() && isRTL ? 'thumbnails-wrapper-rtl' : ''}`}
+                className={`image-gallery-thumbnails-wrapper ${thumbnailNavClass} ${thumbnailPosition} ${!this._isThumbnailVertical() && isRTL ? 'thumbnails-wrapper-rtl' : ''}`}
                 style={this._getThumbnailBarHeight()}
               >
                 {
                   this.props.showThumbnailsNav && this._showThumbnailsNav() &&
                     <span ref={this._onThumbnailMounted} >
                       {this.props.renderThumbnailsLeftNav(
-                        slideThumbnailsLeft, !this._canSlideThumbnailsLeft(), this._isThumbnailHorizontal()
+                        slideThumbnailsLeft, !this._canSlideThumbnailsLeft(), this._isThumbnailVertical()
                       )}
                       {this.props.renderThumbnailsRightNav(
-                        slideThumbnailsRight, !this._canSlideThumbnailsRight(), this._isThumbnailHorizontal()
+                        slideThumbnailsRight, !this._canSlideThumbnailsRight(), this._isThumbnailVertical()
                       )}
                     </span>
                 }


### PR DESCRIPTION
После обновления галереи до актуальной версии появился баг: при переходе в полноэкранный режим и обратно, периодически, не корректно сдвигались превьюшки.